### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To enable FACEBOOK login follow this guide https://developers.facebook.com/docs/
  
 ##Login with Google Plus
 To enable GOOGLE Plus Login follow this guide https://developers.google.com/identity/sign-in/ios/sdk/
-- Add to your XCode project Google Plus frameworks and in your main UIViewController set
+- Add to your Xcode project Google Plus frameworks and in your main UIViewController set
 <pre>	[SongtreeController instance].googlePlusClientID = @"YOUR_GOOGLE_APP_ID”;</pre>
 - Get a configuration file on Google Developers Console
 - In the Project > Target > Info > URL Types panel, create a new item and paste your REVERSED_CLIENT_ID into the URL Schemes field. You can find your REVERSED_CLIENT_ID in the GoogleService-Info.plist file.


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
